### PR TITLE
set pynini==2.1.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "tn": ["*.fst"],
         "itn": ["*.fst"],
     },
-    install_requires=['pynini', 'importlib_resources'],
+    install_requires=['pynini==2.1.5', 'importlib_resources'],
     entry_points={
         "console_scripts": [
             "wetn = tn.main:main",


### PR DESCRIPTION
if not, it will install pynini-2.1.5.post1, then raise Error

```
Collecting pynini
  Using cached https://mirrors.cloud.tencent.com/pypi/packages/e5/f5/4a9d6e0484883dabec02b6896d5e2f3455b3d1907b1996006d1cd2843d44/pynini-2.1.5.post1.tar.gz (788 kB)
......
      gcc -pthread -B /home/ubuntu/miniconda3/compiler_compat -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem /home/ubuntu/miniconda3/include -fPIC -O2 -isystem /home/ubuntu/miniconda3/include -fPIC -I/home/ubuntu/miniconda3/include/python3.11 -c extensions/_pywrapfst.cpp -o build/temp.linux-x86_64-cpython-311/extensions/_pywrapfst.o -std=c++17 -Wno-register -Wno-deprecated-declarations -Wno-unused-function -Wno-unused-local-typedefs -funsigned-char
      extensions/_pywrapfst.cpp:813:10: fatal error: fst/util.h: No such file or directory
        813 | #include <fst/util.h>
            |          ^~~~~~~~~~~~
      compilation terminated.
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]
```