### PR TITLE
[itn] 车牌号5位6位，包含零

### DIFF
--- a/itn/chinese/rules/license_plate.py
+++ b/itn/chinese/rules/license_plate.py
@@ -27,8 +27,11 @@ class LicensePlate(Processor):
 
     def build_tagger(self):
         digit = string_file('itn/chinese/data/number/digit.tsv')  # 1 ~ 9
+        zero = string_file('itn/chinese/data/number/zero.tsv')  # 0
+        digits = zero | digit
         province = string_file(
             'itn/chinese/data/license_plate/province.tsv')  # 皖
-        license_plate = province + self.ALPHA + (self.ALPHA | digit)**5
+        license_plate = province + self.ALPHA + (self.ALPHA | digits)**5
+        license_plate |= province + self.ALPHA + (self.ALPHA | digits)**6
         tagger = insert('value: "') + license_plate + insert('"')
         self.tagger = self.add_tokens(tagger)

--- a/itn/chinese/test/data/license_plate.txt
+++ b/itn/chinese/test/data/license_plate.txt
@@ -1,2 +1,3 @@
 鄂a七l六二u => 鄂a7l62u
 皖C九B三四E => 皖C9B34E
+京A零七ZX三F => 京A07ZX3F


### PR DESCRIPTION
`weitn --text "京A零七ZX三F"`

char { value: "京" } char { value: "A" } char { value: "零" } char { value: "七" } char { value: "Z" } char { value: "X" } char { value: "三" } char { value: "F" }
京A零七ZX三F

`python -m itn --text "京A零七ZX三F" --overwrite_cache`

licenseplate { value: "京A07ZX3F" }
京A07ZX3F