### PR TITLE
fix: use module-level logger to allow user control over log level

### DIFF
--- a/tn/processor.py
+++ b/tn/processor.py
@@ -18,6 +18,13 @@ import string
 
 from pynini import Fst, cdrewrite, cross, difference, escape, invert, shortestpath, union
 from pynini.lib import byte, utf8
+
+logger = logging.getLogger("wetext")
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(asctime)s WETEXT %(levelname)s %(message)s"))
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
 from pynini.lib.pynutil import delete, insert
 
 from tn.token_parser import TokenParser
@@ -70,13 +77,6 @@ class Processor:
         self.verbalizer = self.delete_tokens(verbalizer)
 
     def build_fst(self, prefix, cache_dir, overwrite_cache):
-        logger = logging.getLogger("wetext-{}".format(self.name))
-        logger.setLevel(logging.INFO)
-        handler = logging.StreamHandler()
-        fmt = logging.Formatter("%(asctime)s WETEXT %(levelname)s %(message)s")
-        handler.setFormatter(fmt)
-        logger.addHandler(handler)
-
         os.makedirs(cache_dir, exist_ok=True)
         tagger_name = "{}_tagger.fst".format(prefix)
         verbalizer_name = "{}_verbalizer.fst".format(prefix)


### PR DESCRIPTION
Closes #311

## Summary

- Replace per-call logger creation in `build_fst()` with a single module-level `"wetext"` logger
- Logger is initialized once with INFO level and a StreamHandler, but users can override after import:

```python
import logging
logging.getLogger("wetext").setLevel(logging.WARNING)
```

**Before:** Every `build_fst()` call created a new logger, set INFO level, and added a handler — users could not suppress logs, and handlers accumulated causing duplicate output.

**After:** Single logger, configured once, user-controllable.

## Test plan

- [x] All 1393 unit tests pass
- [x] Verified logs are suppressed when user sets WARNING level
- [ ] CI passes