### PR TITLE
fix: remove contraction expansions from whitelist

### DIFF
--- a/tn/english/data/whitelist/tts.tsv
+++ b/tn/english/data/whitelist/tts.tsv
@@ -3048,9 +3048,3 @@ Z. Y.	ZY
 Z.Y.	ZY
 Z. Z.	ZZ
 Z.Z.	ZZ
-here's	here is
-you're	you are
-i'm	i am
-Here's	Here is
-You're	You are
-I'm	I am


### PR DESCRIPTION
Closes #290

## Summary

Remove `here's`, `Here's`, `you're`, `You're`, `i'm`, `I'm` from `tts.tsv`. These entries caused words like `where's` and `there's` to be incorrectly split because the whitelist matched from the middle of a word.

**Before:** `where's` → `w here is`, `there's` → `t here is`
**After:** `where's` → `where's`, `there's` → `there's`

## Test plan

- [x] All 1400 unit tests pass
- [x] CI passes