### PR TITLE
refactor: rename shadowed mm variable in Date rule

### DIFF
--- a/tn/chinese/rules/date.py
+++ b/tn/chinese/rules/date.py
@@ -39,17 +39,17 @@ class Date(Processor):
 
         year = insert('year: "') + yyyy + insert('年"')
         month = insert('month: "') + (m | mm) + insert('"')
+        month_two_digit = insert('month: "') + mm + insert('"')
         day = insert('day: "') + (d | dd) + insert('"')
 
         # yyyy/m/d | yyyy/mm/dd | dd/mm/yyyy
         # yyyy/0m | 0m/yyyy | 0m/dd
-        mm = insert('month: "') + mm + insert('"')
         date = (
             (year + rmsign + month + rmsign + day)
             | (day + rmsign + month + rmsign + year)
-            | (year + rmsign + mm)
-            | (mm + rmsign + year)
-            | (mm + rmsign + day)
+            | (year + rmsign + month_two_digit)
+            | (month_two_digit + rmsign + year)
+            | (month_two_digit + rmsign + day)
         )
         tagger = self.add_tokens(date)
 


### PR DESCRIPTION
Closes #297

## Summary

Replace the confusing variable shadowing where `mm` was redefined with a separate `month_two_digit` variable for clarity. No behavior change — the two-digit-only month constraint for `0m/yyyy` and `0m/dd` patterns is preserved.

## Test plan

- [x] All 1400 unit tests pass
- [x] CI passes