### PR TITLE
fix: add missing space between comma-separated digit groups

### DIFF
--- a/tn/english/rules/cardinal.py
+++ b/tn/english/rules/cardinal.py
@@ -72,7 +72,13 @@ class Cardinal(Processor):
                     + single_digits_graph
                     + self.INSERT_SPACE
                     + single_digits_graph
-                ).plus
+                    + (self.INSERT_SPACE + pynutil.delete(",")
+                       + single_digits_graph
+                       + self.INSERT_SPACE
+                       + single_digits_graph
+                       + self.INSERT_SPACE
+                       + single_digits_graph).star
+                )
             )
 
         graph = (


### PR DESCRIPTION
Closes #291 (the threetwo bug)

## Summary

Fix missing space between digit groups in `single_digits_graph_with_commas`. Numbers like `0,013,225` were normalized to `oh zero one threetwo two five` — the last digit of one group and the first digit of the next were concatenated.

**Before:** `0,013,225` → `oh zero one threetwo two five`
**After:** `0,013,225` → `oh zero one three two two five`

Regarding the speed question in the issue: English TN is slower than Chinese TN (~17ms vs ~3ms) because the English FST has significantly more states (larger rule set, non-deterministic mode). The recent refactoring (#333) already improved build time by 4x. Runtime compose+shortestpath cost is proportional to FST size and hard to optimize further without simplifying the grammar.

## Test plan

- [x] All 1400 unit tests pass
- [x] CI passes