### PR TITLE
fix: relax pynini version constraint to >=2.1.6

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -9,9 +9,10 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.9]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -13,6 +13,7 @@ jobs:
   unit-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.9]
@@ -40,6 +41,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[test] ${{ runner.os == 'Windows' && '--no-deps' || '' }}
+          pip install flake8 pytest importlib_resources
       - name: Lint with flake8
         shell: bash -el {0}
         run: |

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - '**.py'
       - '**.tsv'
+      - '**.toml'
+      - '**.yml'
 
 jobs:
   unit-test:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -20,20 +20,31 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - name: Set up Conda
+        uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
+          activate-environment: test
+      - name: Install openfst (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install openfst
+          echo "CPLUS_INCLUDE_PATH=/opt/homebrew/include:$CPLUS_INCLUDE_PATH" >> $GITHUB_ENV
+          echo "LIBRARY_PATH=/opt/homebrew/lib:$LIBRARY_PATH" >> $GITHUB_ENV
+      - name: Install pynini via conda (Windows)
+        if: runner.os == 'Windows'
+        shell: bash -el {0}
+        run: conda install -c conda-forge pynini
       - name: Install dependencies
+        shell: bash -el {0}
         run: |
           python -m pip install --upgrade pip
-          pip install .[test]
+          pip install .[test] ${{ runner.os == 'Windows' && '--no-deps' || '' }}
       - name: Lint with flake8
+        shell: bash -el {0}
         run: |
-          # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
-        run: |
-          pytest
+        shell: bash -el {0}
+        run: pytest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -15,19 +15,47 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
-        python-version: [3.9]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.9']
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }} (non-Windows)
+        if: runner.os != 'Windows'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install openfst (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install openfst
+          echo "CPLUS_INCLUDE_PATH=/opt/homebrew/include:$CPLUS_INCLUDE_PATH" >> $GITHUB_ENV
+          echo "LIBRARY_PATH=/opt/homebrew/lib:$LIBRARY_PATH" >> $GITHUB_ENV
+      - name: Install dependencies (non-Windows)
+        if: runner.os != 'Windows'
         run: |
           python -m pip install --upgrade pip
           pip install .[test]
+      - name: Set up Conda (Windows)
+        if: runner.os == 'Windows'
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          activate-environment: test
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        shell: bash -el {0}
+        run: |
+          conda install -c conda-forge pynini
+          python -m pip install --upgrade pip
+          pip install .[test] --no-deps
+          pip install flake8 pytest importlib_resources
+      - name: Lint with flake8
+        shell: bash -el {0}
+        run: |
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
+        shell: bash -el {0}
         run: pytest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -15,38 +15,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [windows-latest]
         python-version: [3.9]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          activate-environment: test
-      - name: Install openfst (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install openfst
-          echo "CPLUS_INCLUDE_PATH=/opt/homebrew/include:$CPLUS_INCLUDE_PATH" >> $GITHUB_ENV
-          echo "LIBRARY_PATH=/opt/homebrew/lib:$LIBRARY_PATH" >> $GITHUB_ENV
-      - name: Install pynini via conda (Windows)
-        if: runner.os == 'Windows'
-        shell: bash -el {0}
-        run: conda install -c conda-forge pynini
       - name: Install dependencies
-        shell: bash -el {0}
         run: |
           python -m pip install --upgrade pip
-          pip install .[test] ${{ runner.os == 'Windows' && '--no-deps' || '' }}
-          pip install flake8 pytest importlib_resources
-      - name: Lint with flake8
-        shell: bash -el {0}
-        run: |
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          pip install .[test]
       - name: Test with pytest
-        shell: bash -el {0}
         run: pytest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -26,12 +26,27 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache Homebrew (macOS)
+        if: runner.os == 'macOS'
+        uses: actions/cache@v4
+        with:
+          path: |
+            /opt/homebrew/Cellar/openfst
+            /opt/homebrew/include/fst
+            /opt/homebrew/lib/libfst*
+          key: brew-openfst-${{ runner.os }}
       - name: Install openfst (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install openfst
+          brew install openfst || true
           echo "CPLUS_INCLUDE_PATH=/opt/homebrew/include:$CPLUS_INCLUDE_PATH" >> $GITHUB_ENV
           echo "LIBRARY_PATH=/opt/homebrew/lib:$LIBRARY_PATH" >> $GITHUB_ENV
+      - name: Cache pip (non-Windows)
+        if: runner.os != 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
       - name: Install dependencies (non-Windows)
         if: runner.os != 'Windows'
         run: |
@@ -43,6 +58,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: test
+          use-only-tar-bz2: true
+      - name: Cache Conda (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: C:\Miniconda\envs\test
+          key: conda-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         shell: bash -el {0}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     # Core dependencies for text processing functionality
-    "pynini>=2.1.6,<2.1.7",
+    "pynini>=2.1.6",
     "importlib_resources"
 ]
 

--- a/tn/chinese/test/utils.py
+++ b/tn/chinese/test/utils.py
@@ -19,7 +19,7 @@ def parse_test_case(file_name):
     file = os.path.dirname(os.path.abspath(__file__)) + os.path.sep + file_name
 
     delimiter = "=>"
-    with open(file) as fin:
+    with open(file, encoding="utf-8") as fin:
         for line in fin:
             assert delimiter in line
             arr = line.strip().split(delimiter)


### PR DESCRIPTION
Closes #317
Closes #292
Closes #321
Closes #328

## Summary

- **Relax pynini version**: `>=2.1.6,<2.1.7` → `>=2.1.6`, fixing macOS installation (#317, #292, #328)
- **Add Japanese data to package-data**: itn and tn Japanese TSV files were missing from the package (#321)
- **CI**: Add macOS and Windows to test matrix, with caching for brew/conda/pip
- **Fix Windows tests**: Specify `encoding="utf-8"` when reading test data files

## Test plan

- [x] Ubuntu CI passes
- [x] macOS CI passes
- [x] Windows CI passes