### PR TITLE
feat: support nbest output in normalize/tag

### DIFF
--- a/tn/processor.py
+++ b/tn/processor.py
@@ -104,21 +104,29 @@ class Processor:
             logger.info("fst path: {}".format(tagger_path))
             logger.info("          {}".format(verbalizer_path))
 
-    def tag(self, input):
+    def tag(self, input, nbest=1):
         if len(input) == 0:
-            return ""
+            return "" if nbest == 1 else [""]
         input = escape(input)
         lattice = input @ self.tagger
-        return shortestpath(lattice, nshortest=1, unique=True).string()
+        if nbest == 1:
+            return shortestpath(lattice, nshortest=1, unique=True).string()
+        lattice = shortestpath(lattice.project("output").rmepsilon(), nshortest=nbest, unique=True)
+        paths = lattice.paths()
+        results = []
+        while not paths.done():
+            results.append(paths.ostring())
+            paths.next()
+        return results
 
     def verbalize(self, input):
-        # Only words from the blacklist are contained.
         if len(input) == 0:
             return ""
         output = TokenParser(self.ordertype).reorder(input)
-        # We need escape for pynini to build the fst from string.
         lattice = escape(output) @ self.verbalizer
         return shortestpath(lattice, nshortest=1, unique=True).string()
 
-    def normalize(self, input):
-        return self.verbalize(self.tag(input))
+    def normalize(self, input, nbest=1):
+        if nbest == 1:
+            return self.verbalize(self.tag(input))
+        return [self.verbalize(tagged) for tagged in self.tag(input, nbest)]


### PR DESCRIPTION
Closes #296

## Summary

Add `nbest` parameter to `normalize()` and `tag()`:
- `normalize(input)` — returns a single string (default, backward compatible)
- `normalize(input, nbest=N)` — returns a list of N-best results

## Examples

```python
from tn.chinese.normalizer import Normalizer
n = Normalizer()

n.normalize('海淀区108号', nbest=3)
# ['海淀区一百零八号', '海淀区十八号', '海淀区幺零八号']

n.normalize('收费24.0', nbest=3)
# ['收费二十四点零', '收费二四点零', '收费2四点零']
```

## Test plan

- [x] All 1400 unit tests pass (backward compatible, default nbest=1)
- [x] CI passes