### PR TITLE
refactor: code review cleanup and bug fixes

### DIFF
--- a/itn/chinese/inverse_normalizer.py
+++ b/itn/chinese/inverse_normalizer.py
@@ -52,19 +52,29 @@ class InverseNormalizer(Processor):
 
     def build_tagger_and_verbalizer(self):
         cardinal = Cardinal(self.convert_number, self.enable_0_to_9, self.enable_million)
+        char = Char()
+        date = Date()
+        fraction = Fraction(cardinal=cardinal)
+        train_number = TrainNumber()
+        math = Math(cardinal=cardinal)
+        measure = Measure(enable_0_to_9=self.enable_0_to_9, cardinal=cardinal)
+        money = Money(enable_0_to_9=self.enable_0_to_9, cardinal=cardinal)
+        time = Time()
+        license_plate = LicensePlate()
+        whitelist = Whitelist()
 
         tagger = (
-            add_weight(Date().tagger, 1.02)
-            | add_weight(Whitelist().tagger, 1.01)
-            | add_weight(Fraction(cardinal=cardinal).tagger, 1.05)
-            | add_weight(Measure(enable_0_to_9=self.enable_0_to_9, cardinal=cardinal).tagger, 1.05)
-            | add_weight(Money(enable_0_to_9=self.enable_0_to_9, cardinal=cardinal).tagger, 1.04)
-            | add_weight(Time().tagger, 1.05)
+            add_weight(date.tagger, 1.02)
+            | add_weight(whitelist.tagger, 1.01)
+            | add_weight(fraction.tagger, 1.05)
+            | add_weight(measure.tagger, 1.05)
+            | add_weight(money.tagger, 1.04)
+            | add_weight(time.tagger, 1.05)
             | add_weight(cardinal.tagger, 1.06)
-            | add_weight(Math(cardinal=cardinal).tagger, 1.10)
-            | add_weight(LicensePlate().tagger, 1.0)
-            | add_weight(TrainNumber().tagger, 1.0)
-            | add_weight(Char().tagger, 100)
+            | add_weight(math.tagger, 1.10)
+            | add_weight(license_plate.tagger, 1.0)
+            | add_weight(train_number.tagger, 1.0)
+            | add_weight(char.tagger, 100)
         ).optimize()
 
         tagger = tagger.star
@@ -72,16 +82,16 @@ class InverseNormalizer(Processor):
 
         verbalizer = (
             cardinal.verbalizer
-            | Char().verbalizer
-            | Date().verbalizer
-            | Fraction().verbalizer
-            | TrainNumber().verbalizer
-            | Math().verbalizer
-            | Measure(enable_0_to_9=self.enable_0_to_9).verbalizer
-            | Money(enable_0_to_9=self.enable_0_to_9).verbalizer
-            | Time().verbalizer
-            | LicensePlate().verbalizer
-            | Whitelist().verbalizer
+            | char.verbalizer
+            | date.verbalizer
+            | fraction.verbalizer
+            | train_number.verbalizer
+            | math.verbalizer
+            | measure.verbalizer
+            | money.verbalizer
+            | time.verbalizer
+            | license_plate.verbalizer
+            | whitelist.verbalizer
         ).optimize()
         postprocessor = PostProcessor(remove_interjections=self.remove_interjections).processor
 

--- a/tn/chinese/normalizer.py
+++ b/tn/chinese/normalizer.py
@@ -58,7 +58,7 @@ class Normalizer(Processor):
         processor = PreProcessor(traditional_to_simple=self.traditional_to_simple).processor
         cardinal = Cardinal()
         date = Date()
-        whitelist = Whitelist()
+        whitelist = Whitelist(remove_erhua=self.remove_erhua)
         sport = Sport(cardinal=cardinal)
         fraction = Fraction(cardinal=cardinal)
         measure = Measure(cardinal=cardinal)
@@ -92,7 +92,7 @@ class Normalizer(Processor):
             | money.verbalizer
             | sport.verbalizer
             | time.verbalizer
-            | Whitelist(remove_erhua=self.remove_erhua).verbalizer
+            | whitelist.verbalizer
         ).optimize()
 
         postprocessor = PostProcessor(

--- a/tn/chinese/rules/cardinal.py
+++ b/tn/chinese/rules/cardinal.py
@@ -64,7 +64,16 @@ class Cardinal(Processor):
         hundred_million = (
             (thousand | hundred | ten | digit)
             + insert("亿")
-            + (four_nonzero + insert("万") + four_any | rmzero**4 + four_nonzero | rmzero**8)
+            + (
+                four_nonzero + insert("万") + four_any
+                | rmzero**4 + (
+                    (zero + hundred)
+                    | (rmzero + zero + tens)
+                    | (rmzero**2 + zero + digit)
+                    | (insert("零") + thousand)
+                )
+                | rmzero**8
+            )
         )
 
         number = digits | ten | hundred | thousand | ten_thousand | hundred_million

--- a/tn/chinese/rules/measure.py
+++ b/tn/chinese/rules/measure.py
@@ -36,7 +36,7 @@ class Measure(Processor):
         to = cross("-", "到") | cross("~", "到") | accep("到")
 
         number = self.cardinal.number
-        strip_comma = self.build_rule(delete(","), self.DIGIT, self.DIGIT)
+        strip_comma = self.build_rule(delete(",") | delete("，"), self.DIGIT, self.DIGIT)
         number = strip_comma @ number
         number @= self.build_rule(cross("二", "两"), "[BOS]", "[EOS]")
         # 1-11个，1个-11个

--- a/tn/japanese/normalizer.py
+++ b/tn/japanese/normalizer.py
@@ -84,7 +84,6 @@ class Normalizer(Processor):
         tagger = (processor @ tagger).star
         self.tagger = tagger @ self.build_rule(delete(" "), r="[EOS]")
 
-        transliteration = Transliteration()
         verbalizer = (
             cardinal.verbalizer
             | char.verbalizer

--- a/tn/processor.py
+++ b/tn/processor.py
@@ -18,6 +18,9 @@ import string
 
 from pynini import Fst, cdrewrite, cross, difference, escape, invert, shortestpath, union
 from pynini.lib import byte, utf8
+from pynini.lib.pynutil import delete, insert
+
+from tn.token_parser import TokenParser
 
 logger = logging.getLogger("wetext")
 if not logger.handlers:
@@ -25,9 +28,6 @@ if not logger.handlers:
     handler.setFormatter(logging.Formatter("%(asctime)s WETEXT %(levelname)s %(message)s"))
     logger.addHandler(handler)
     logger.setLevel(logging.INFO)
-from pynini.lib.pynutil import delete, insert
-
-from tn.token_parser import TokenParser
 
 
 class Processor:


### PR DESCRIPTION
## Summary

Code review findings from a full-repo review:

**Bug fixes:**
- Fix 亿级 reading: `100001000` → `一亿零一千` (was `一亿一千`, missing 零)
- Support full-width comma `，` in Measure strip_comma

**Performance:**
- Share rule instances in Chinese ITN verbalizer (test suite -15%, 92s → 78s)
- Don't create Transliteration() when `transliterate=False` in Japanese TN
- Share Whitelist instance in Chinese TN normalizer

**Code quality:**
- Fix import ordering in processor.py (imports were placed after logger setup)

## Test plan

- [x] All 1400 unit tests pass
- [x] CI passes