### PR TITLE
fix: restore Chinese ITN measure fields in TokenParser

### DIFF
--- a/tn/token_parser.py
+++ b/tn/token_parser.py
@@ -27,11 +27,13 @@ EN_TN_ORDERS = {
     "money": ["integer_part", "fractional_part", "quantity", "currency_maj"],
 }
 ITN_ORDERS = {
-    "date": ["year", "month", "day"],
+    "date": ["year", "month", "day", "preserve_order"],
     "fraction": ["sign", "numerator", "denominator"],
-    "measure": ["numerator", "denominator", "value"],
+    "measure": ["numerator", "denominator", "value", "units"],
     "money": ["currency", "value", "decimal"],
     "time": ["hour", "minute", "second", "noon"],
+    "telephone": ["value"],
+    "electronic": ["username", "domain", "protocol"],
 }
 
 


### PR DESCRIPTION
## Summary

The previous PR (#356) replaced measure's ITN_ORDERS from `["numerator", "denominator", "value"]` to `["value", "units"]`, breaking Chinese ITN's `每小时X` pattern which uses `numerator`/`denominator` fields.

Fix: include both Chinese and English field names: `["numerator", "denominator", "value", "units"]`.

Also adds `telephone`, `electronic`, and `preserve_order` fields for the new English ITN rules.

## Test plan

- [x] All 1443 unit tests pass (including Chinese ITN `每小时` patterns)
- [x] CI passes