### PR TITLE
fix: OpenFst compatibility + add C++ runtime CI (#359)

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -1,0 +1,22 @@
+name: Runtime Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'runtime/**'
+      - '.github/workflows/runtime.yml'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build runtime
+        run: |
+          cmake -B build -S runtime -DBUILD_TESTING=OFF
+          cmake --build build -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)

--- a/runtime/processor/wetext_processor.cc
+++ b/runtime/processor/wetext_processor.cc
@@ -14,15 +14,15 @@
 
 #include "processor/wetext_processor.h"
 
-using fst::TokenType;
+using fst::StringTokenType;
 
 namespace wetext {
 Processor::Processor(const std::string& tagger_path,
                      const std::string& verbalizer_path) {
   tagger_.reset(StdVectorFst::Read(tagger_path));
   verbalizer_.reset(StdVectorFst::Read(verbalizer_path));
-  compiler_ = std::make_shared<StringCompiler<StdArc>>(TokenType::BYTE);
-  printer_ = std::make_shared<StringPrinter<StdArc>>(TokenType::BYTE);
+  compiler_ = std::make_shared<StringCompiler<StdArc>>(StringTokenType::BYTE);
+  printer_ = std::make_shared<StringPrinter<StdArc>>(StringTokenType::BYTE);
 
   if (tagger_path.find("zh_tn_") != tagger_path.npos) {
     parse_type_ = ParseType::kZH_TN;

--- a/runtime/processor/wetext_processor.cc
+++ b/runtime/processor/wetext_processor.cc
@@ -14,15 +14,13 @@
 
 #include "processor/wetext_processor.h"
 
-using fst::TokenType;
-
 namespace wetext {
 Processor::Processor(const std::string& tagger_path,
                      const std::string& verbalizer_path) {
   tagger_.reset(StdVectorFst::Read(tagger_path));
   verbalizer_.reset(StdVectorFst::Read(verbalizer_path));
-  compiler_ = std::make_shared<StringCompiler<StdArc>>(TokenType::BYTE);
-  printer_ = std::make_shared<StringPrinter<StdArc>>(TokenType::BYTE);
+  compiler_ = std::make_shared<StringCompiler<StdArc>>();
+  printer_ = std::make_shared<StringPrinter<StdArc>>();
 
   if (tagger_path.find("zh_tn_") != tagger_path.npos) {
     parse_type_ = ParseType::kZH_TN;

--- a/runtime/processor/wetext_processor.cc
+++ b/runtime/processor/wetext_processor.cc
@@ -14,15 +14,15 @@
 
 #include "processor/wetext_processor.h"
 
-using fst::StringTokenType;
+using fst::TokenType;
 
 namespace wetext {
 Processor::Processor(const std::string& tagger_path,
                      const std::string& verbalizer_path) {
   tagger_.reset(StdVectorFst::Read(tagger_path));
   verbalizer_.reset(StdVectorFst::Read(verbalizer_path));
-  compiler_ = std::make_shared<StringCompiler<StdArc>>(StringTokenType::BYTE);
-  printer_ = std::make_shared<StringPrinter<StdArc>>(StringTokenType::BYTE);
+  compiler_ = std::make_shared<StringCompiler<StdArc>>(TokenType::BYTE);
+  printer_ = std::make_shared<StringPrinter<StdArc>>(TokenType::BYTE);
 
   if (tagger_path.find("zh_tn_") != tagger_path.npos) {
     parse_type_ = ParseType::kZH_TN;


### PR DESCRIPTION
## Summary
- Fix `TokenType` compilation error by omitting the explicit `TokenType::BYTE` argument — both `StringCompiler` and `StringPrinter` default to BYTE mode, so this works with both the csukuangfj/openfst fork (`fst::TokenType`) and official OpenFst 1.8+ (`fst::StringTokenType`)
- Add `runtime.yml` CI workflow to build C++ runtime on `runtime/**` changes

Fixes #359

## Test plan
- [x] CI: C++ runtime builds on ubuntu and macos