### PR TITLE
fix: English TN spurious space after opening punctuation

### DIFF
--- a/tn/english/normalizer.py
+++ b/tn/english/normalizer.py
@@ -78,7 +78,7 @@ class Normalizer(Processor):
         ).optimize() + (add_weight(punctuation.tagger, 2.00).plus | self.DELETE_SPACE)
         self.tagger = (delete(" ").star + tagger.star) @ self.build_rule(delete(" "), r="[EOS]")
 
-        verbalizer = (
+        classify = (
             cardinal.verbalizer
             | ordinal.verbalizer
             | word.verbalizer
@@ -92,7 +92,15 @@ class Normalizer(Processor):
             | electronic.verbalizer
             | serial.verbalizer
             | whitelist.verbalizer
-            | punctuation.verbalizer
             | rang.verbalizer
-        ).optimize() + (punctuation.verbalizer.plus | self.INSERT_SPACE)
-        self.verbalizer = verbalizer.star @ self.build_rule(delete(" "), r="[EOS]")
+        ).optimize()
+        punct = punctuation.verbalizer.optimize()
+        # Punct tokens carry surrounding spacing in their values (the tagger's
+        # add_weight(accep(" "), -1.0).star absorbs spaces around punctuation).
+        # So punct tokens handle their own spacing and don't need INSERT_SPACE.
+        # Only classify tokens need INSERT_SPACE for inter-word spacing.
+        verbalizer = (
+            classify + (punct.plus | self.INSERT_SPACE)
+            | punct + (punct.plus | self.DELETE_SPACE)
+        ).star
+        self.verbalizer = verbalizer @ self.build_rule(delete(" "), r="[EOS]")

--- a/tn/english/test/data/normalizer.txt
+++ b/tn/english/test/data/normalizer.txt
@@ -6,3 +6,6 @@ Try searching for 'Toyota' or 'Investment' => Try searching for 'Toyota' or 'Inv
 "" => ""
 The HTML tag <p> defines a paragraph. => The HTML tag <p> defines a paragraph.
  hello world => hello world
+"So, one hundred thousand merit shouldn't be a problem." => "So, one hundred thousand merit shouldn't be a problem."
+"hello" => "hello"
+(hello) => (hello)


### PR DESCRIPTION
Fixed https://github.com/pengzhendong/wetext/issues/14

## Summary

- English TN verbalizer's `INSERT_SPACE` was applied uniformly between all non-punct tokens, causing unwanted spaces after opening quotes/parens (e.g., `"hello"` → `" hello"`, `(hello)` → `( hello)`)
- Split the verbalizer pattern so classify tokens use `INSERT_SPACE` for inter-word spacing while punct tokens use `DELETE_SPACE` — punct values already carry surrounding spacing via the tagger's `add_weight(accep(" "), -1.0).star`
- Add 3 test cases covering the reported issue and related patterns

Fixes wenet-e2e/WeTextProcessing downstream issue: https://github.com/pengzhendong/wetext/issues/14

## Test plan

- [x] All 792 existing tests pass (English + Chinese TN/ITN)
- [x] New test cases added: `"So, one hundred thousand merit shouldn't be a problem."`, `"hello"`, `(hello)`
- [x] Verified no regression on: `hello, world`, `He said "hello"`, `a"b"`, `hello "world"`