### PR TITLE
fix: harden runtime FST and JNI handling

### DIFF
--- a/runtime/bindings/android/wetextprocessing.cc
+++ b/runtime/bindings/android/wetextprocessing.cc
@@ -15,6 +15,7 @@
 
 #include <exception>
 #include <string>
+#include <utility>
 
 #include "processor/wetext_processor.h"
 #include "utils/wetext_flags.h"
@@ -59,55 +60,94 @@ bool CopyJString(JNIEnv* env, jstring string, std::string* output) {
   return true;
 }
 
-void ThrowIllegalState(JNIEnv* env, const char* message) {
-  jclass exception_class = env->FindClass("java/lang/IllegalStateException");
+void ThrowJavaException(JNIEnv* env, const char* class_name,
+                        const char* message) {
+  jclass exception_class = env->FindClass(class_name);
   if (exception_class != nullptr) {
     env->ThrowNew(exception_class, message);
   }
 }
+
+void ThrowIllegalState(JNIEnv* env, const char* message) {
+  ThrowJavaException(env, "java/lang/IllegalStateException", message);
+}
+
+void ThrowRuntimeException(JNIEnv* env, const char* message) {
+  ThrowJavaException(env, "java/lang/RuntimeException", message);
+}
 }
 
 void init(JNIEnv* env, jobject, jstring jModelDir) {
-  std::string model_dir;
-  if (!CopyJString(env, jModelDir, &model_dir)) {
-    return;
-  }
-
   try {
+    std::string model_dir;
+    if (!CopyJString(env, jModelDir, &model_dir)) {
+      return;
+    }
+
     std::string tnTagger = model_dir + "/zh_tn_tagger.fst";
     std::string tnVerbalizer = model_dir + "/zh_tn_verbalizer.fst";
-    processorTN = std::make_shared<wetext::Processor>(tnTagger, tnVerbalizer);
+    auto tn_processor =
+        std::make_shared<wetext::Processor>(tnTagger, tnVerbalizer);
 
     std::string itnTagger = model_dir + "/zh_itn_tagger.fst";
     std::string itnVerbalizer = model_dir + "/zh_itn_verbalizer.fst";
-    processorITN = std::make_shared<wetext::Processor>(itnTagger, itnVerbalizer);
+    auto itn_processor =
+        std::make_shared<wetext::Processor>(itnTagger, itnVerbalizer);
+
+    processorTN = std::move(tn_processor);
+    processorITN = std::move(itn_processor);
   } catch (const std::exception& error) {
-    processorTN.reset();
-    processorITN.reset();
     ThrowIllegalState(env, error.what());
+  } catch (...) {
+    ThrowIllegalState(env, "Failed to initialize text processors");
   }
 }
 
 jstring normalize(JNIEnv* env, jobject, jstring input) {
-  std::string input_text;
-  if (!CopyJString(env, input, &input_text)) {
-    return nullptr;
-  }
-  std::string tagged_text = processorTN->Tag(input_text);
-  std::string normalized_text = processorTN->Verbalize(tagged_text);
+  try {
+    if (processorTN == nullptr) {
+      ThrowIllegalState(env, "Text normalization processor is not initialized");
+      return nullptr;
+    }
 
-  return env->NewStringUTF(normalized_text.c_str());
+    std::string input_text;
+    if (!CopyJString(env, input, &input_text)) {
+      return nullptr;
+    }
+    std::string tagged_text = processorTN->Tag(input_text);
+    std::string normalized_text = processorTN->Verbalize(tagged_text);
+
+    return env->NewStringUTF(normalized_text.c_str());
+  } catch (const std::exception& error) {
+    ThrowRuntimeException(env, error.what());
+  } catch (...) {
+    ThrowRuntimeException(env, "Text normalization failed");
+  }
+  return nullptr;
 }
 
 jstring inverse_normalize(JNIEnv* env, jobject, jstring input) {
-  std::string input_text;
-  if (!CopyJString(env, input, &input_text)) {
-    return nullptr;
-  }
-  std::string tagged_text = processorITN->Tag(input_text);
-  std::string normalized_text = processorITN->Verbalize(tagged_text);
+  try {
+    if (processorITN == nullptr) {
+      ThrowIllegalState(env,
+                        "Inverse text normalization processor is not initialized");
+      return nullptr;
+    }
 
-  return env->NewStringUTF(normalized_text.c_str());
+    std::string input_text;
+    if (!CopyJString(env, input, &input_text)) {
+      return nullptr;
+    }
+    std::string tagged_text = processorITN->Tag(input_text);
+    std::string normalized_text = processorITN->Verbalize(tagged_text);
+
+    return env->NewStringUTF(normalized_text.c_str());
+  } catch (const std::exception& error) {
+    ThrowRuntimeException(env, error.what());
+  } catch (...) {
+    ThrowRuntimeException(env, "Inverse text normalization failed");
+  }
+  return nullptr;
 }
 }  // namespace wetextprocessing
 

--- a/runtime/bindings/android/wetextprocessing.cc
+++ b/runtime/bindings/android/wetextprocessing.cc
@@ -13,6 +13,9 @@
 // limitations under the License.
 #include <jni.h>
 
+#include <exception>
+#include <string>
+
 #include "processor/wetext_processor.h"
 #include "utils/wetext_flags.h"
 #include "utils/wetext_string.h"
@@ -22,20 +25,74 @@ namespace wetextprocessing {
 std::shared_ptr<wetext::Processor> processorTN;
 std::shared_ptr<wetext::Processor> processorITN;
 
+namespace {
+class UtfStringChars {
+ public:
+  UtfStringChars(JNIEnv* env, jstring string)
+      : env_(env),
+        string_(string),
+        chars_(env->GetStringUTFChars(string, nullptr)) {}
+
+  UtfStringChars(const UtfStringChars&) = delete;
+  UtfStringChars& operator=(const UtfStringChars&) = delete;
+
+  ~UtfStringChars() {
+    if (chars_ != nullptr) {
+      env_->ReleaseStringUTFChars(string_, chars_);
+    }
+  }
+
+  const char* get() const { return chars_; }
+
+ private:
+  JNIEnv* env_;
+  jstring string_;
+  const char* chars_;
+};
+
+bool CopyJString(JNIEnv* env, jstring string, std::string* output) {
+  UtfStringChars chars(env, string);
+  if (chars.get() == nullptr) {
+    return false;
+  }
+  *output = chars.get();
+  return true;
+}
+
+void ThrowIllegalState(JNIEnv* env, const char* message) {
+  jclass exception_class = env->FindClass("java/lang/IllegalStateException");
+  if (exception_class != nullptr) {
+    env->ThrowNew(exception_class, message);
+  }
+}
+}
+
 void init(JNIEnv* env, jobject, jstring jModelDir) {
-  const char* pModelDir = env->GetStringUTFChars(jModelDir, nullptr);
+  std::string model_dir;
+  if (!CopyJString(env, jModelDir, &model_dir)) {
+    return;
+  }
 
-  std::string tnTagger = std::string(pModelDir) + "/zh_tn_tagger.fst";
-  std::string tnVerbalizer = std::string(pModelDir) + "/zh_tn_verbalizer.fst";
-  processorTN = std::make_shared<wetext::Processor>(tnTagger, tnVerbalizer);
+  try {
+    std::string tnTagger = model_dir + "/zh_tn_tagger.fst";
+    std::string tnVerbalizer = model_dir + "/zh_tn_verbalizer.fst";
+    processorTN = std::make_shared<wetext::Processor>(tnTagger, tnVerbalizer);
 
-  std::string itnTagger = std::string(pModelDir) + "/zh_itn_tagger.fst";
-  std::string itnVerbalizer = std::string(pModelDir) + "/zh_itn_verbalizer.fst";
-  processorITN = std::make_shared<wetext::Processor>(itnTagger, itnVerbalizer);
+    std::string itnTagger = model_dir + "/zh_itn_tagger.fst";
+    std::string itnVerbalizer = model_dir + "/zh_itn_verbalizer.fst";
+    processorITN = std::make_shared<wetext::Processor>(itnTagger, itnVerbalizer);
+  } catch (const std::exception& error) {
+    processorTN.reset();
+    processorITN.reset();
+    ThrowIllegalState(env, error.what());
+  }
 }
 
 jstring normalize(JNIEnv* env, jobject, jstring input) {
-  std::string input_text = std::string(env->GetStringUTFChars(input, nullptr));
+  std::string input_text;
+  if (!CopyJString(env, input, &input_text)) {
+    return nullptr;
+  }
   std::string tagged_text = processorTN->Tag(input_text);
   std::string normalized_text = processorTN->Verbalize(tagged_text);
 
@@ -43,7 +100,10 @@ jstring normalize(JNIEnv* env, jobject, jstring input) {
 }
 
 jstring inverse_normalize(JNIEnv* env, jobject, jstring input) {
-  std::string input_text = std::string(env->GetStringUTFChars(input, nullptr));
+  std::string input_text;
+  if (!CopyJString(env, input, &input_text)) {
+    return nullptr;
+  }
   std::string tagged_text = processorITN->Tag(input_text);
   std::string normalized_text = processorITN->Verbalize(tagged_text);
 

--- a/runtime/processor/wetext_processor.cc
+++ b/runtime/processor/wetext_processor.cc
@@ -14,13 +14,22 @@
 
 #include "processor/wetext_processor.h"
 
+#include <stdexcept>
+
 #include "utils/wetext_log.h"
 
 namespace wetext {
 Processor::Processor(const std::string& tagger_path,
                      const std::string& verbalizer_path) {
   tagger_.reset(StdVectorFst::Read(tagger_path));
+  if (tagger_ == nullptr) {
+    throw std::runtime_error("Failed to load tagger FST: " + tagger_path);
+  }
   verbalizer_.reset(StdVectorFst::Read(verbalizer_path));
+  if (verbalizer_ == nullptr) {
+    throw std::runtime_error("Failed to load verbalizer FST: " +
+                             verbalizer_path);
+  }
   compiler_ = std::make_shared<StringCompiler<StdArc>>();
   printer_ = std::make_shared<StringPrinter<StdArc>>();
 

--- a/runtime/test/CMakeLists.txt
+++ b/runtime/test/CMakeLists.txt
@@ -20,3 +20,15 @@ target_link_libraries(processor_test PUBLIC wetext_processor)
 target_compile_definitions(processor_test PRIVATE
   WETEXT_TN_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../tn")
 gtest_discover_tests(processor_test)
+
+# Host-side JNI regression tests exercise the same native entry points as the
+# Android shared library. They are optional when a host-only build has no JDK.
+find_package(JNI QUIET)
+if(JNI_FOUND)
+  add_executable(android_jni_test
+    android_jni_test.cc
+    ../bindings/android/wetextprocessing.cc)
+  target_include_directories(android_jni_test PRIVATE ${JNI_INCLUDE_DIRS})
+  target_link_libraries(android_jni_test PUBLIC wetext_processor)
+  gtest_discover_tests(android_jni_test)
+endif()

--- a/runtime/test/android_jni_test.cc
+++ b/runtime/test/android_jni_test.cc
@@ -1,0 +1,268 @@
+// Copyright (c) 2026 WeTextProcessing contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+#include <jni.h>
+
+#include <filesystem>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "fst/fstlib.h"
+#include "gtest/gtest.h"
+#include "processor/wetext_processor.h"
+
+namespace wetextprocessing {
+extern std::shared_ptr<wetext::Processor> processorTN;
+extern std::shared_ptr<wetext::Processor> processorITN;
+
+void init(JNIEnv* env, jobject object, jstring model_dir);
+jstring normalize(JNIEnv* env, jobject object, jstring input);
+jstring inverse_normalize(JNIEnv* env, jobject object, jstring input);
+}  // namespace wetextprocessing
+
+namespace {
+struct FakeJniState {
+  std::string string_value;
+  std::string exception_class;
+  std::string exception_message;
+  bool exception_pending = false;
+  bool throw_on_get_string = false;
+};
+
+FakeJniState* current_state = nullptr;
+
+jclass FakeFindClass(JNIEnv*, const char* name) {
+  current_state->exception_class = name;
+  return reinterpret_cast<jclass>(1);
+}
+
+jint FakeThrowNew(JNIEnv*, jclass, const char* message) {
+  current_state->exception_message = message;
+  current_state->exception_pending = true;
+  return JNI_OK;
+}
+
+const char* FakeGetStringUTFChars(JNIEnv*, jstring, jboolean*) {
+  if (current_state->throw_on_get_string) {
+    throw std::runtime_error("simulated JNI string allocation failure");
+  }
+  return current_state->string_value.c_str();
+}
+
+void FakeReleaseStringUTFChars(JNIEnv*, jstring, const char*) {}
+
+jstring FakeNewStringUTF(JNIEnv*, const char*) {
+  return reinterpret_cast<jstring>(2);
+}
+
+class FakeJNIEnv {
+ public:
+  explicit FakeJNIEnv(std::string string_value) {
+    state_.string_value = std::move(string_value);
+    current_state = &state_;
+    functions_.FindClass = FakeFindClass;
+    functions_.ThrowNew = FakeThrowNew;
+    functions_.GetStringUTFChars = FakeGetStringUTFChars;
+    functions_.ReleaseStringUTFChars = FakeReleaseStringUTFChars;
+    functions_.NewStringUTF = FakeNewStringUTF;
+    env_.functions = &functions_;
+  }
+
+  ~FakeJNIEnv() { current_state = nullptr; }
+
+  JNIEnv* get() { return &env_; }
+  FakeJniState& state() { return state_; }
+
+ private:
+  FakeJniState state_;
+  JNINativeInterface_ functions_{};
+  JNIEnv_ env_{};
+};
+
+void ClearProcessors() {
+  wetextprocessing::processorTN.reset();
+  wetextprocessing::processorITN.reset();
+}
+
+std::filesystem::path InstallMinimalProcessors() {
+  const auto model_dir = std::filesystem::path(testing::TempDir()) /
+                         "wetextprocessing-jni-models";
+  std::error_code error;
+  std::filesystem::remove_all(model_dir, error);
+  std::filesystem::create_directories(model_dir);
+
+  fst::StdVectorFst fst;
+  const auto state = fst.AddState();
+  fst.SetStart(state);
+  fst.SetFinal(state, fst::StdArc::Weight::One());
+  if (!fst.Write((model_dir / "zh_tn_tagger.fst").string()) ||
+      !fst.Write((model_dir / "zh_tn_verbalizer.fst").string())) {
+    return {};
+  }
+
+  wetextprocessing::processorTN = std::make_shared<wetext::Processor>(
+      (model_dir / "zh_tn_tagger.fst").string(),
+      (model_dir / "zh_tn_verbalizer.fst").string());
+  wetextprocessing::processorITN = wetextprocessing::processorTN;
+  return model_dir;
+}
+
+bool WriteSingleArcFst(const std::filesystem::path& path, int input_label,
+                       int output_label) {
+  fst::StdVectorFst fst;
+  const auto start = fst.AddState();
+  const auto final = fst.AddState();
+  fst.SetStart(start);
+  fst.SetFinal(final, fst::StdArc::Weight::One());
+  fst.AddArc(start, fst::StdArc(input_label, output_label,
+                                fst::StdArc::Weight::One(), final));
+  return fst.Write(path.string());
+}
+
+std::filesystem::path InstallMalformedProcessors() {
+  const auto model_dir = std::filesystem::path(testing::TempDir()) /
+                         "wetextprocessing-jni-malformed-models";
+  std::error_code error;
+  std::filesystem::remove_all(model_dir, error);
+  std::filesystem::create_directories(model_dir);
+
+  if (!WriteSingleArcFst(model_dir / "zh_tn_tagger.fst", 'x', 'b') ||
+      !WriteSingleArcFst(model_dir / "zh_tn_verbalizer.fst", 'b', 'b') ||
+      !WriteSingleArcFst(model_dir / "zh_itn_tagger.fst", 'x', 'b') ||
+      !WriteSingleArcFst(model_dir / "zh_itn_verbalizer.fst", 'b', 'b')) {
+    return {};
+  }
+
+  wetextprocessing::processorTN = std::make_shared<wetext::Processor>(
+      (model_dir / "zh_tn_tagger.fst").string(),
+      (model_dir / "zh_tn_verbalizer.fst").string());
+  wetextprocessing::processorITN = std::make_shared<wetext::Processor>(
+      (model_dir / "zh_itn_tagger.fst").string(),
+      (model_dir / "zh_itn_verbalizer.fst").string());
+  return model_dir;
+}
+
+TEST(AndroidJniTest, NormalizeBeforeInitThrowsIllegalState) {
+  ClearProcessors();
+  FakeJNIEnv fake_env("input");
+
+  EXPECT_EQ(wetextprocessing::normalize(fake_env.get(), nullptr,
+                                        reinterpret_cast<jstring>(1)),
+            nullptr);
+  EXPECT_TRUE(fake_env.state().exception_pending);
+  EXPECT_EQ(fake_env.state().exception_class,
+            "java/lang/IllegalStateException");
+}
+
+TEST(AndroidJniTest, FailedInitLeavesProcessingUnavailable) {
+  ClearProcessors();
+  FakeJNIEnv fake_env("/path/that/does/not/exist");
+
+  wetextprocessing::init(fake_env.get(), nullptr,
+                         reinterpret_cast<jstring>(1));
+  ASSERT_TRUE(fake_env.state().exception_pending);
+  EXPECT_EQ(fake_env.state().exception_class,
+            "java/lang/IllegalStateException");
+
+  fake_env.state().exception_pending = false;
+  fake_env.state().exception_class.clear();
+  EXPECT_EQ(wetextprocessing::inverse_normalize(
+                fake_env.get(), nullptr, reinterpret_cast<jstring>(1)),
+            nullptr);
+  EXPECT_TRUE(fake_env.state().exception_pending);
+  EXPECT_EQ(fake_env.state().exception_class,
+            "java/lang/IllegalStateException");
+}
+
+TEST(AndroidJniTest, InitExceptionsBecomeJavaIllegalStateExceptions) {
+  ClearProcessors();
+  FakeJNIEnv fake_env("input");
+  fake_env.state().throw_on_get_string = true;
+
+  EXPECT_NO_FATAL_FAILURE(wetextprocessing::init(
+      fake_env.get(), nullptr, reinterpret_cast<jstring>(1)));
+  EXPECT_TRUE(fake_env.state().exception_pending);
+  EXPECT_EQ(fake_env.state().exception_class,
+            "java/lang/IllegalStateException");
+}
+
+TEST(AndroidJniTest, FailedReinitPreservesPublishedProcessors) {
+  const auto model_dir = InstallMinimalProcessors();
+  ASSERT_FALSE(model_dir.empty());
+  FakeJNIEnv fake_env(model_dir.string());
+
+  wetextprocessing::init(fake_env.get(), nullptr,
+                         reinterpret_cast<jstring>(1));
+  ASSERT_TRUE(fake_env.state().exception_pending);
+  ASSERT_NE(wetextprocessing::processorTN, nullptr);
+  ASSERT_NE(wetextprocessing::processorITN, nullptr);
+
+  fake_env.state().exception_pending = false;
+  fake_env.state().exception_class.clear();
+  fake_env.state().string_value.clear();
+  EXPECT_EQ(wetextprocessing::normalize(fake_env.get(), nullptr,
+                                        reinterpret_cast<jstring>(1)),
+            reinterpret_cast<jstring>(2));
+  EXPECT_FALSE(fake_env.state().exception_pending);
+
+  ClearProcessors();
+  std::error_code error;
+  std::filesystem::remove_all(model_dir, error);
+}
+
+TEST(AndroidJniTest, ProcessingExceptionsBecomeJavaRuntimeExceptions) {
+  const auto model_dir = InstallMinimalProcessors();
+  ASSERT_FALSE(model_dir.empty());
+  FakeJNIEnv fake_env("input");
+  fake_env.state().throw_on_get_string = true;
+
+  EXPECT_EQ(wetextprocessing::normalize(fake_env.get(), nullptr,
+                                        reinterpret_cast<jstring>(1)),
+            nullptr);
+  EXPECT_TRUE(fake_env.state().exception_pending);
+  EXPECT_EQ(fake_env.state().exception_class, "java/lang/RuntimeException");
+
+  fake_env.state().exception_pending = false;
+  fake_env.state().exception_class.clear();
+  EXPECT_EQ(wetextprocessing::inverse_normalize(
+                fake_env.get(), nullptr, reinterpret_cast<jstring>(1)),
+            nullptr);
+  EXPECT_TRUE(fake_env.state().exception_pending);
+  EXPECT_EQ(fake_env.state().exception_class, "java/lang/RuntimeException");
+
+  ClearProcessors();
+  std::error_code error;
+  std::filesystem::remove_all(model_dir, error);
+}
+
+TEST(AndroidJniTest, ProcessingParserExceptionsBecomeJavaRuntimeExceptions) {
+  const auto model_dir = InstallMalformedProcessors();
+  ASSERT_FALSE(model_dir.empty());
+  FakeJNIEnv fake_env("x");
+
+  EXPECT_EQ(wetextprocessing::normalize(fake_env.get(), nullptr,
+                                        reinterpret_cast<jstring>(1)),
+            nullptr);
+  EXPECT_TRUE(fake_env.state().exception_pending);
+  EXPECT_EQ(fake_env.state().exception_class, "java/lang/RuntimeException");
+
+  fake_env.state().exception_pending = false;
+  fake_env.state().exception_class.clear();
+  EXPECT_EQ(wetextprocessing::inverse_normalize(
+                fake_env.get(), nullptr, reinterpret_cast<jstring>(1)),
+            nullptr);
+  EXPECT_TRUE(fake_env.state().exception_pending);
+  EXPECT_EQ(fake_env.state().exception_class, "java/lang/RuntimeException");
+
+  ClearProcessors();
+  std::error_code error;
+  std::filesystem::remove_all(model_dir, error);
+}
+}  // namespace

--- a/runtime/test/processor_test.cc
+++ b/runtime/test/processor_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <filesystem>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -74,10 +75,23 @@ TEST_P(ProcessorTest, NormalizeTest) {
 }
 
 TEST(ProcessorLoadTest, ThrowsWhenFstFilesCannotBeLoaded) {
-  EXPECT_THROW(
-      wetext::Processor("/tmp/zh_tn_missing_tagger.fst",
-                        "/tmp/zh_tn_missing_verbalizer.fst"),
-      std::runtime_error);
+  const auto temp_dir = std::filesystem::path(testing::TempDir());
+  const auto missing_tagger = temp_dir / "missing-tagger.fst";
+  const auto missing_verbalizer = temp_dir / "missing-verbalizer.fst";
+
+  EXPECT_THROW(wetext::Processor(missing_tagger.string(),
+                                 missing_verbalizer.string()),
+               std::runtime_error);
+}
+
+TEST(ProcessorLoadTest, ThrowsWhenVerbalizerFstCannotBeLoaded) {
+  const auto missing_verbalizer =
+      std::filesystem::path(testing::TempDir()) / "missing-verbalizer.fst";
+
+  const std::string tagger_path =
+      std::string(WETEXT_TN_DIR) + "/zh_tn_tagger.fst";
+  EXPECT_THROW(wetext::Processor(tagger_path, missing_verbalizer.string()),
+               std::runtime_error);
 }
 
 std::vector<std::pair<std::string, std::string>> test_cases =

--- a/runtime/test/processor_test.cc
+++ b/runtime/test/processor_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -70,6 +71,13 @@ class ProcessorTest
 
 TEST_P(ProcessorTest, NormalizeTest) {
   EXPECT_EQ(processor->Normalize(written), spoken);
+}
+
+TEST(ProcessorLoadTest, ThrowsWhenFstFilesCannotBeLoaded) {
+  EXPECT_THROW(
+      wetext::Processor("/tmp/zh_tn_missing_tagger.fst",
+                        "/tmp/zh_tn_missing_verbalizer.fst"),
+      std::runtime_error);
 }
 
 std::vector<std::pair<std::string, std::string>> test_cases =


### PR DESCRIPTION
## Summary

- Fail construction with a clear exception when a tagger or verbalizer FST cannot be loaded.
- Release JNI UTF string buffers through a non-copyable RAII wrapper and surface FST initialization failures as Java exceptions.
- Add a regression test for missing FST assets.

## Verification

- Built the processor test and C API targets with CMake.
- Ran 15 focused C++ tests: all passed.
- Verified the C API returns a null handle for missing FST files.
- Passed a host-JNI syntax check; repository CI covers the Android NDK build.

## Notes

The full FST-backed runtime test set was not run locally because this environment has Python 3.14 and no compatible Pynini installation to generate the required model artifacts.